### PR TITLE
Update references to the is keyword and Std.is in accordance with the latest version of Haxe

### DIFF
--- a/comparing-haxe-and-actionscript/deep-dive/operators.md
+++ b/comparing-haxe-and-actionscript/deep-dive/operators.md
@@ -112,7 +112,7 @@ The following operators are different between Haxe and ActionScript 3.0:
 
  * `as`
     
-    You can convert `object as Type` to `Std.isOfType(object, Type) ? cast (object, Type) : null` or `(object is Type) ? cast (object, Type) : null`as a one-line replacement. However, there are usually more elegant ways to convert this code.
+    You can convert `object as Type` to `Std.isOfType(object, Type) ? cast (object, Type) : null` or `(object is Type) ? cast (object, Type) : null` as a one-line replacement. However, there are usually more elegant ways to convert this code.
     
     If you know the type already, then you can use an unsafe cast:
 

--- a/comparing-haxe-and-actionscript/deep-dive/operators.md
+++ b/comparing-haxe-and-actionscript/deep-dive/operators.md
@@ -112,7 +112,7 @@ The following operators are different between Haxe and ActionScript 3.0:
 
  * `as`
     
-    You can convert `object as Type` to `Std.is(object, Type) ? cast(object, Type) : null` as a one-line replacement. However, there are usually more elegant ways to convert this code.
+    You can convert `object as Type` to `Std.isOfType(object, Type) ? cast (object, Type) : null` or `(object is Type) ? cast (object, Type) : null`as a one-line replacement. However, there are usually more elegant ways to convert this code.
     
     If you know the type already, then you can use an unsafe cast:
 
@@ -129,7 +129,7 @@ The following operators are different between Haxe and ActionScript 3.0:
     Lastly you can check the type of the object and return `null` in order to fully replicate the behavior of the `as` keyword from ActionScript 3.0:
     
     ```haxe
-    if (Std.is(object, Type))
+    if (Std.isOfType(object, Type)) // or (object is Type)
     {
         typedObject = cast object;
     }
@@ -145,11 +145,11 @@ The following operators are different between Haxe and ActionScript 3.0:
     
  * `instanceof`
     
-    The `Std.is` method can be used in most cases where `instanceof` is used in ActionScript 3.0.
+    The `Std.isOfType` method or the `is` keyword can be used in most cases where `instanceof` is used in ActionScript 3.0.
     
  * `is`
     
-    Haxe provides `Std.is` rather than a special operator.
+    Prior to newer versions of Haxe, the `is` keyword did not work, and you had to use `Std.is`. It does work now, and it's worth noting `Std.is` has been deprecated in favor of `Std.isOfType`.
     
  * `::`
     
@@ -161,7 +161,7 @@ The following operators are different between Haxe and ActionScript 3.0:
     
  * `typeof`
     
-    Haxe provides a `Type.typeof` method that can be used to check the type, otherwise `Std.is` is common to determine if the object is of a certain type.
+    Haxe provides a `Type.typeof` method that can be used to check the type, otherwise `Std.isOfType` or the `is` keyword is common to determine if the object is of a certain type.
     
  * `void`
     

--- a/comparing-haxe-and-actionscript/deep-dive/syntax.md
+++ b/comparing-haxe-and-actionscript/deep-dive/syntax.md
@@ -292,12 +292,15 @@ The Haxe programming language is designed to limit the number of keywords, so th
     
  * `instanceof`
     
-    The ActionScript 3.0 keyword, `instanceof`, can be replaced with `Std.is`
+    The ActionScript 3.0 keyword, `instanceof`, can be replaced with `Std.isOfType` or the `is` keyword.
     
     ```haxe
-    trace (Std.is (sprite, DisplayObject));
-    trace (Std.is ("hello", String));
-    trace (Std.is (5, Int));
+    trace (Std.isOfType (sprite, DisplayObject));
+    trace (Std.isOfType ("hello", String));
+    trace (Std.isOfType (5, Int));
+    trace (sprite is DisplayObject);
+    trace ("hello" is String);
+    trace (5 is Int);
     ```
     
  * `internal`

--- a/glossary/cheat-sheet.md
+++ b/glossary/cheat-sheet.md
@@ -202,7 +202,7 @@ type = Class (getDefinitionByName (name);
 ### Haxe
 
 ```haxe
-if (Std.is (vehicle, Car)) {
+if (Std.isOfType (vehicle, Car)) { // or (vehicle is car)
  
 }
  

--- a/glossary/error-messages.md
+++ b/glossary/error-messages.md
@@ -124,7 +124,7 @@ This might mean that you forgot a parenthesis in your code.
 
 ## Unexpected is
 
-You can replace `Foo is Bar` with `Std.is (Foo, Bar)`
+This shouldn't be a problem in newer versions of Haxe, but if you're still using Haxe 3 you can replace `Foo is Bar` with `Std.is (Foo, Bar)`. It's advised to update Haxe, though.
 
 ## Unexpected as
 


### PR DESCRIPTION
Since is does work in Haxe now (and Std.is has been deprecated in favor of Std.isOfType) I figured updating this documentation to reflect that would be a good idea.